### PR TITLE
feat: add starter for autumn mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,13 @@
 {
-    "typescript.tsdk": "./node_modules/typescript/lib",
-    "files.eol": "\n",
-    "json.schemas": [
-        {
-            "fileMatch": [
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "files.eol": "\n",
+  "json.schemas": [
+    {
+      "fileMatch": [
                 "/manifest.json"
             ],
-            "url": "http://json.schemastore.org/chrome-manifest"
-        }
-    ]
+      "url": "http://json.schemastore.org/chrome-manifest"
+    }
+  ],
+  "prettier.enable": false
 }

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ Chrome Extension, TypeScript and Visual Studio Code
 
 ```
 npm install
+npm run build
 ```
 
+Navigate to `chrome://extensions/`, toggle "Developer mode" on. Click on "Load unpacked" then navigate to the repo and "Select". Toggle the "Lattice labs" extension on.
+
+While developing, you can run `npm run watch` and reload via `chrome://extensions/` to watch your changes
 ## Import as Visual Studio Code project
 
 ...

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,7 +19,7 @@
           "matches": ["<all_urls>"],
           "js": ["js/vendor.js", "js/content_script.js"],
           "css": [
-            "lights.css"
+            "lights.css", "spooky.css"
           ]
       }
   ],

--- a/public/spooky.css
+++ b/public/spooky.css
@@ -1,0 +1,44 @@
+
+
+
+.falling-leaf {
+    position: fixed;
+    top: -10px;
+    z-index: 9999;
+    opacity: 0.8;
+    clip-path: polygon(
+      50% 0%,
+      75% 30%,
+      100% 40%,
+      90% 70%,
+      100% 100%,
+      50% 80%,
+      0% 100%,
+      10% 70%,
+      0% 40%,
+      25% 30%
+    );
+  
+    border-radius: 0%;
+    animation: falling-leaf linear infinite;
+  }
+  
+  @keyframes falling-leaf {
+    0% {
+      /* Starting position */
+      top: -10px;
+      left: calc(100% * var(--random-left, 0));
+      transform: rotate(-15deg); /* Slight initial rotation */
+    }
+    50% {
+      /* Middle position - slight sway back and forth */
+      transform: rotate(15deg); /* Opposite rotation */
+    }
+    100% {
+      /* Ending position */
+      top: 100%;
+      left: calc(5vw + 100% * var(--random-left, 0));
+      transform: rotate(15deg); /* Final rotation */
+    }
+  }
+  

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -1,4 +1,5 @@
 import { toggleChristmasLights } from './christmaslights/christmaslights';
+import { toggleSpookySeason } from './spookyseason/spookyseason';
 import { toggleDarkMode } from "./darkmode/darkmode";
 import { traverseAndConvert } from "./bionic/bionic";
 import { toggleMakePremium } from "./premium/premium";
@@ -7,7 +8,12 @@ chrome.runtime.onMessage.addListener(function (msg: any, sender, sendResponse) {
   if (msg.type === "christmasLights") {
     toggleChristmasLights(msg.enable);
     sendResponse("Toggled Christmas lights");
-  } else if (msg.action === "addBionicReading") {
+  }
+    else if (msg.type === 'spookySeason') {
+      toggleSpookySeason(msg.enable);
+      sendResponse('Toggled Spooky Season');
+  }
+  else if (msg.action === "addBionicReading") {
     sendResponse("Activated bionic reading");
     traverseAndConvert(document.body);
   } else if (msg.type === "darkMode") {
@@ -24,6 +30,10 @@ chrome.runtime.onMessage.addListener(function (msg: any, sender, sendResponse) {
 // On script load, check the stored state
 chrome.storage.sync.get(["christmasLights"], (result) => {
   toggleChristmasLights(result.christmasLights);
+});
+
+chrome.storage.sync.get(['spookySeason'], result => {
+  toggleSpookySeason(result.spookySeason);
 });
 
 chrome.storage.sync.get(["darkMode"], (result) => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -13,16 +13,18 @@ const Popup = () => {
   const [isMakePremiumEnabled, setIsMakePremiumEnabled] =
     useState<boolean>(false);
   const [isLightsEnabled, setIsLightsEnabled] = useState<boolean>(false);
+  const [isSpookySeasonEnabled, setIsSpookySeasonEnabled] = useState<boolean>(false);
 
   // On component mount, load the saved state
   useEffect(() => {
     chrome.storage.sync.get(
-      ["christmasLights", "darkMode", "makePremium"],
+      ["christmasLights", "darkMode", "makePremium", "spookySeason"],
       (result) => {
         console.log(result);
         setIsLightsEnabled(result.christmasLights ?? false);
         setIsDarkModeEnabled(result.darkMode ?? false);
         setIsMakePremiumEnabled(result.makePremium ?? false);
+        setIsSpookySeasonEnabled(result.spookySeason ?? false);
       }
     );
   }, []);
@@ -43,8 +45,26 @@ const Popup = () => {
     });
   }, []);
 
+  const handleSpookySeasonChange = () => {
+    setIsSpookySeasonEnabled((prevState) => {
+      const newState = !prevState;
+      chrome.storage.sync.set({ spookySeason: newState });
+
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        const tab = tabs[0];
+        if (tab.id) {
+          chrome.tabs.sendMessage(tab.id, {
+            type: "spookySeason",
+            enable: newState,
+          });
+        }
+      });
+      return newState;
+    });
+  };
+
   const handleLightsChange = () => {
-    setIsLightsEnabled((prevState) => {
+    setIsSpookySeasonEnabled((prevState) => {
       const newState = !prevState;
       chrome.storage.sync.set({ christmasLights: newState });
 
@@ -104,8 +124,8 @@ const Popup = () => {
           tab.id,
           { action: "addBionicReading" },
           function (response) {
-            console.log(response);
-          }
+          console.log(response);
+        }
         );
       }
     });

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -3,6 +3,8 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import { BsTree } from "react-icons/bs";
 import { BsFillTreeFill } from "react-icons/bs";
+import { GiPumpkinMask } from "react-icons/gi";
+import { GiPumpkinLantern } from "react-icons/gi";
 import { PiMoonStarsBold } from "react-icons/pi";
 import { PiMoonStarsFill } from "react-icons/pi";
 
@@ -193,13 +195,13 @@ const Popup = () => {
               className={`flex flex-row font-medium items-center bg-gradient-to-r ${
                 !isSpookySeasonEnabled
                   ? "from-slate-200 to-slate-500"
-                  : "from-emerald-300 to-emerald-700 text-emerald-950"
-              } rounded-md py-1 px-2 hover:bg-gradient-to-r hover:from-emerald-300 hover:to-emerald-700 hover:text-white`}
+                  : "from-orange-300 to-yellow-700 text-red-950"
+              } rounded-md py-1 px-2 hover:bg-gradient-to-r hover:from-orange-300 hover:to-yellow-700 hover:text-white`}
             >
               {!isSpookySeasonEnabled ? (
-                <BsTree className="mr-1" />
+                <GiPumpkinLantern className="mr-1" />
               ) : (
-                <BsFillTreeFill className="mr-1" />
+                <GiPumpkinMask className="mr-1" />
               )}
               Spooky season
             </button>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -64,7 +64,7 @@ const Popup = () => {
   };
 
   const handleLightsChange = () => {
-    setIsSpookySeasonEnabled((prevState) => {
+    setIsLightsEnabled((prevState) => {
       const newState = !prevState;
       chrome.storage.sync.set({ christmasLights: newState });
 
@@ -185,6 +185,23 @@ const Popup = () => {
                 <BsFillTreeFill className="mr-1" />
               )}
               Christmas lights
+            </button>
+          </div>
+          <div className="my-1">
+            <button
+              onClick={handleSpookySeasonChange}
+              className={`flex flex-row font-medium items-center bg-gradient-to-r ${
+                !isSpookySeasonEnabled
+                  ? "from-slate-200 to-slate-500"
+                  : "from-emerald-300 to-emerald-700 text-emerald-950"
+              } rounded-md py-1 px-2 hover:bg-gradient-to-r hover:from-emerald-300 hover:to-emerald-700 hover:text-white`}
+            >
+              {!isSpookySeasonEnabled ? (
+                <BsTree className="mr-1" />
+              ) : (
+                <BsFillTreeFill className="mr-1" />
+              )}
+              Spooky season
             </button>
           </div>
           <div className="my-1">

--- a/src/spookyseason/spookyseason.ts
+++ b/src/spookyseason/spookyseason.ts
@@ -1,0 +1,50 @@
+import { findElementByXPath } from '../utils';
+
+export function toggleSpookySeason(enable: boolean) {
+  if (enable) {
+    addSpookySeason();
+  } else {
+    removeSpookySeason();
+  }
+}
+
+export function addSpookySeason() {
+  createFallingLeaves();
+}
+
+function removeSpookySeason() {
+  removeFallingLeaves();
+}
+
+function createFallingLeaves() {
+  const numberOfLeaves = 25;
+
+  for (let i = 0; i < numberOfLeaves; i++) {
+    const leaf = document.createElement('div');
+    leaf.className = 'falling-leaf';
+
+    const size = Math.random() * 5 + 25;
+    const duration = Math.random() * 5 + 5;
+
+    leaf.style.width = `${size}px`;
+    leaf.style.height = `${size}px`;
+    leaf.style.animationDuration = `${duration}s`;
+    leaf.style.setProperty('--random-left', Math.random().toString());
+
+    const randomAutumnalColor = getRandomAutumnalColor();
+    leaf.style.background = randomAutumnalColor;
+    document.body.appendChild(leaf);
+  }
+}
+
+function removeFallingLeaves() {
+  while (document.getElementsByClassName('falling-leaf').length > 0) {
+    document.getElementsByClassName('falling-leaf')[0].remove();
+  }
+}
+
+function getRandomAutumnalColor() {
+  const colors = ['#8B4513', '#D2691E', '#A52A2A', '#FFD700']; // Browns, oranges, and reds
+  const randomIndex = Math.floor(Math.random() * colors.length);
+  return colors[randomIndex];
+}


### PR DESCRIPTION
Adds "spooky season" option to menu
When enabled, turns on falling leaf animation

Sorry about some of the whitespace changes -- I disabled prettier partway through

<img width="1764" alt="image" src="https://github.com/chibat/chrome-extension-typescript-starter/assets/49885346/d8e81770-e7f2-48cb-8286-7f771363c1cf">

<img width="521" alt="image" src="https://github.com/gsornsen/lattice-labs/assets/49885346/ebc0f7bc-215f-468a-a9b4-a8fa9ee9c828">

